### PR TITLE
Answer yes to rustup questions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install Rust
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         source $HOME/.cargo/env
 
     - name: Build


### PR DESCRIPTION
To prevent the installation failing with:
```
rustup: Unable to run interactively. Run with -y to accept defaults, --help for additional options
```
